### PR TITLE
new: pass environment to shell

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -1,8 +1,20 @@
 package commands
 
+import (
+	"fmt"
+)
+
 var Available = make(map[string]*Command)
 
 type Variables map[string]string
+
+func (v Variables) AsEnv() []string {
+	env := make([]string, len(v))
+	for k, v := range v {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
 
 type Environment struct {
 	Vars Variables

--- a/commands/shell.go
+++ b/commands/shell.go
@@ -29,6 +29,7 @@ func shellDo(env *Environment, args ...string) error {
 	} else {
 		msg("shell", "%s\n", args[0])
 		cmd := exec.Command(sh, "-c", args[0])
+		cmd.Env = env.Vars.AsEnv()
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Cool project.

This PR passes the env.Vars to the invoked shell command. This makes it possible to, e.g. get the $VERSION variable if necessary in the shell script.